### PR TITLE
fix: replace dimmer `CanvasGroup` with `SubViewportContainer`

### DIFF
--- a/addons/godot_tours/overlays/dimmer/dimmer.gd
+++ b/addons/godot_tours/overlays/dimmer/dimmer.gd
@@ -1,5 +1,5 @@
 @tool
-extends CanvasGroup
+extends SubViewportContainer
 
 const DimmerMaskPackedScene := preload("dimmer_mask.tscn")
 
@@ -25,7 +25,7 @@ func add_mask() -> ColorRect:
 
 
 func refresh() -> void:
-	film_color_rect.size = root.size
+	size = root.size
 
 
 func toggle_dimmer_mask(is_on: bool) -> void:

--- a/addons/godot_tours/overlays/dimmer/dimmer.tscn
+++ b/addons/godot_tours/overlays/dimmer/dimmer.tscn
@@ -1,14 +1,27 @@
-[gd_scene load_steps=2 format=3 uid="uid://bp0jk65vdkenb"]
+[gd_scene load_steps=3 format=3 uid="uid://bp0jk65vdkenb"]
 
 [ext_resource type="Script" path="res://addons/godot_tours/overlays/dimmer/dimmer.gd" id="1_30fag"]
 
-[node name="Dimmer" type="CanvasGroup" groups=["dimmer"]]
+[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_cvwys"]
+blend_mode = 3
+
+[node name="Dimmer" type="SubViewportContainer" groups=["dimmer"]]
 self_modulate = Color(1, 1, 1, 0.6)
+material = SubResource("CanvasItemMaterial_cvwys")
+offset_right = 1920.0
+offset_bottom = 1011.0
+mouse_filter = 2
+stretch = true
 script = ExtResource("1_30fag")
 
-[node name="FilmColorRect" type="ColorRect" parent="."]
+[node name="SubViewport" type="SubViewport" parent="."]
+handle_input_locally = false
+size = Vector2i(1920, 1011)
+render_target_update_mode = 4
+
+[node name="FilmColorRect" type="ColorRect" parent="SubViewport"]
 unique_name_in_owner = true
 offset_right = 1920.0
 offset_bottom = 1011.0
 mouse_default_cursor_shape = 8
-color = Color(0, 0, 0, 1)
+color = Color(0.6, 0.6, 0.6, 1)

--- a/addons/godot_tours/overlays/dimmer/dimmer.tscn
+++ b/addons/godot_tours/overlays/dimmer/dimmer.tscn
@@ -8,20 +8,26 @@ blend_mode = 3
 [node name="Dimmer" type="SubViewportContainer" groups=["dimmer"]]
 self_modulate = Color(1, 1, 1, 0.6)
 material = SubResource("CanvasItemMaterial_cvwys")
-offset_right = 1920.0
-offset_bottom = 1011.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 stretch = true
 script = ExtResource("1_30fag")
 
 [node name="SubViewport" type="SubViewport" parent="."]
 handle_input_locally = false
-size = Vector2i(1920, 1011)
+size = Vector2i(1152, 648)
 render_target_update_mode = 4
 
 [node name="FilmColorRect" type="ColorRect" parent="SubViewport"]
 unique_name_in_owner = true
-offset_right = 1920.0
-offset_bottom = 1011.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_default_cursor_shape = 8
 color = Color(0.6, 0.6, 0.6, 1)

--- a/addons/godot_tours/overlays/dimmer/dimmer_mask.tscn
+++ b/addons/godot_tours/overlays/dimmer/dimmer_mask.tscn
@@ -1,8 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://c72o4d1oo88yv"]
-
-[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_rqaeo"]
-blend_mode = 2
+[gd_scene format=3 uid="uid://c72o4d1oo88yv"]
 
 [node name="DimmerMask" type="ColorRect"]
-material = SubResource("CanvasItemMaterial_rqaeo")
 mouse_filter = 2


### PR DESCRIPTION
`CanvasGroup` is known to be a bit bugged so in hopes to fix the dimmer appearing with incorrect colors we use `SubViewportContainer` with a *Material* set to *Blend Mode = Multiply*.

fixes #35