### PR TITLE
Add default bubble tanslate

### DIFF
--- a/addons/godot_tours/bubble/default_bubble.gd
+++ b/addons/godot_tours/bubble/default_bubble.gd
@@ -34,6 +34,8 @@ const VideoStreamPlayerPackedScene := preload("video_stream_player.tscn")
 
 @onready var step_count_label: Label = %StepCountLabel
 
+@onready var view_close_label: Label = %Panel/MarginContainer/ViewClose/Label
+@onready var view_close_label2: Label = %Panel/MarginContainer/ViewClose/Label2
 
 func setup(translation_service: TranslationService, step_count: int) -> void:
 	super(translation_service, step_count)
@@ -41,6 +43,11 @@ func setup(translation_service: TranslationService, step_count: int) -> void:
 	update_locale({
 		back_button: {text = "BACK"},
 		next_button: {text = "NEXT STEP"},
+		finish_button: {text = "END TOUR AND CONTINUE LEARNING"},
+		button_close_no: {text = "NO"},
+		button_close_yes: {text = "YES"},
+		view_close_label: {text = "Close the tour?"},
+		view_close_label2: {text = "Your progress will be lost."},
 	})
 
 

--- a/addons/godot_tours/bubble/locale/ja.po
+++ b/addons/godot_tours/bubble/locale/ja.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.2\n"
+
+msgid "NEXT STEP"
+msgstr "次へ"
+
+msgid "BACK"
+msgstr "戻る"
+
+msgid "END TOUR AND CONTINUE LEARNING"
+msgstr "ツアーを終了して学習を続ける"
+
+msgid "NO"
+msgstr "いいえ"
+
+msgid "YES"
+msgstr "はい"
+
+msgid "Close the tour?"
+msgstr "ツアーを終了しますか？"
+
+msgid "Your progress will be lost."
+msgstr "終了するとここまでの進捗は失われます。"

--- a/addons/godot_tours/bubble/locale/locale.pot
+++ b/addons/godot_tours/bubble/locale/locale.pot
@@ -6,3 +6,18 @@ msgstr ""
 
 msgid "BACK"
 msgstr ""
+
+msgid "END TOUR AND CONTINUE LEARNING"
+msgstr ""
+
+msgid "NO"
+msgstr ""
+
+msgid "YES"
+msgstr ""
+
+msgid "Close the tour?"
+msgstr ""
+
+msgid "Your progress will be lost."
+msgstr ""


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
We have added the ability to make text with a definite default_bubble content translatable.
Furthermore, when activated in Japanese, the corresponding text will be translated into Japanese.


**Does this PR introduce a breaking change?**
No, this doesn’t.


## New feature or change ##


**What is the current behavior?** 
default_bubble will only translate the following text.
- BACK" in back_button
- NEXT STEP" in next_button


**What is the new behavior?**
New text will be translatable.
Please check the content added in the update_locale method of default_bubble.gd to see what is added.

Also, the corresponding text is now translated into Japanese.



**Other information**
Sorry, we could not find the commit guidelines for godot-tours.
Perhaps the commit name does not meet the guidelines.

Visual test results are attached.

![img1](https://github.com/GDQuest/godot-tours/assets/47442969/7a16d646-9d39-4b56-a26d-03686291a8a1)
![img2](https://github.com/GDQuest/godot-tours/assets/47442969/9e355eb4-e8d7-448d-ad64-8b956402893d)
![img3](https://github.com/GDQuest/godot-tours/assets/47442969/7404cdbb-c134-4d0f-9fe6-9d9025533bf7)


