### PR TITLE
Remove \\ from a regular expression hit string

### DIFF
--- a/addons/godot_tours/translation/translation_parser.gd
+++ b/addons/godot_tours/translation/translation_parser.gd
@@ -14,7 +14,7 @@ func _parse_file(path: String, msgids: Array[String], msgids_context_plural: Arr
 	for pattern in PATTERNS:
 		regex.compile(pattern)
 		for regex_match in regex.search_all(source_code):
-			var singular := regex_match.strings[1]
+			var singular := regex_match.strings[1].replace("\\","")
 			var context := regex_match.strings[2]
 			var plural := ""
 			if regex_match.get_group_count() > 2:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.


Related issue (if applicable): #43


**What kind of change does this PR introduce?**
To be closer to the output of Tr(), do not send backslashes included in the statement.


**Does this PR introduce a breaking change?**
No, this doesn’t.


## New feature or change ##


**What is the current behavior?** 
The string hit by the regular expression pattern is sent to the POT without any special processing.
The result is a statement containing a backslash, unlike tr().

**What is the new behavior?**
Removing `\\` before sending to POT.

**Other information**
The following checks have been made, though visually confirmed.
- We applied this change to the current demo and confirmed that the previously untranslated English is now translated into Japanese.
- Generated a POT of the current demo with and without this modification, and confirmed that there is no change in the content except for the `\\`.

I know it is hard to see, but this is the result of the comparison.
![image](https://github.com/GDQuest/godot-tours/assets/47442969/e845d93d-3da7-4c8a-bb0b-a0eaf2cdeb95)
![image](https://github.com/GDQuest/godot-tours/assets/47442969/979ed656-e38c-45e6-a2fd-864cfe7742c5)

